### PR TITLE
Cultures

### DIFF
--- a/com.culture
+++ b/com.culture
@@ -1,0 +1,2 @@
+Another="Another"
+Shortage="Shortage"

--- a/fr.culture
+++ b/fr.culture
@@ -1,0 +1,2 @@
+Another="Encore"
+Shortage="Manque"

--- a/troopers.sh
+++ b/troopers.sh
@@ -12,10 +12,22 @@ then
   friend="roushet"             # avatar's name
 fi
 
+## Culture Specific ##
+ext=${4:-com}
+Another="Another"
+Shortage="Shortage"
+
+## Reading culture file ##
+# /!\ Security Warning /!\
+# This will execute any command present in the .culture file
+source ${prefix}${ext}.culture
+
+
+
 # Check for "raids"
 function check {
-    message=`egrep "(Another|Shortage)" ${prefix}index`
-    if [ "$message" == "Shortage" ] || [ -z "$message" ]
+    message=`egrep "($Another|$Shortage)" ${prefix}index`
+    if [ "$message" == "$Shortage" ] || [ -z "$message" ]
     then
         exit_cycle=1
         mission
@@ -33,7 +45,7 @@ function mission {
     mission_key=`egrep -o -e "chk=[A-Za-z0-9]{6}" ${prefix}index |tail -n1`
     for i in {1..3}
     do
-        curl $curl_opt http://$login.minitroopers.com/b/mission?$mission_key
+        curl $curl_opt http://$login.minitroopers.$ext/b/mission?$mission_key
     done
     fight
 }
@@ -42,13 +54,13 @@ function mission {
 function fight {
     for i in {1..3}
     do
-        curl $curl_opt http://$login.minitroopers.com/b/opp > ${prefix}opp
+        curl $curl_opt http://$login.minitroopers.$ext/b/opp > ${prefix}opp
         fight_key=`egrep -o -e "opp=[0-9]{5,7};chk=[a-zA-Z0-9]{6}" ${prefix}opp|head -n1`
         if [ $selected_enemy -ne 1 ]
         then
-            curl $curl_opt http://$login.minitroopers.com/b/battle?$fight_key
+            curl $curl_opt http://$login.minitroopers.$ext/b/battle?$fight_key
         else
-            curl $curl_opt "http://$login.minitroopers.com/b/battle?$fight_key&friend=$friend"
+            curl $curl_opt "http://$login.minitroopers.$ext/b/battle?$fight_key&friend=$friend"
         fi
     done
 }
@@ -56,19 +68,19 @@ function fight {
 # Login
 if [ $# -gt 1 ]
 then
-    curl $curl_opt -d "login=$login&pass=$password" http://$login.minitroopers.com/login
+    curl $curl_opt -d "login=$login&pass=$password" http://$login.minitroopers.$ext/login
 else
-    curl $curl_opt -d "login=$login" http://$login.minitroopers.com/login
+    curl $curl_opt -d "login=$login" http://$login.minitroopers.$ext/login
 fi
-curl $curl_opt http://$login.minitroopers.com/hq > ${prefix}index
+curl $curl_opt http://$login.minitroopers.$ext/hq > ${prefix}index
 check
 
 # Make raid tasks
 while [ "$exit_cycle" != "1" ]
 do
     key=`egrep -o -e "chk=[A-Za-z0-9]{6}" ${prefix}index |tail -n1`
-    curl $curl_opt http://$login.minitroopers.com/b/raid?$key
-    curl $curl_opt http://$login.minitroopers.com/hq > ${prefix}index
+    curl $curl_opt http://$login.minitroopers.$ext/b/raid?$key
+    curl $curl_opt http://$login.minitroopers.$ext/hq > ${prefix}index
     check
 done
 


### PR DESCRIPTION
Adds the ability to work with the different versions of minitroopers. The script was originally written for minitroopers.com, but won't work with -- say -- minitroopers.fr or minitroopers.es.

(Simply because of the extension mainly, but also because of the parsing of the /hq page to determine when to do raids.)

The problem is solved with .culture files sourced at the beginning of the script to set the variables that need to differ for different cultures.

Regarding the security issue of sourcing external files, I consider it acceptable given the extent of the script and the fact power users can always modify the script directly and don't need to "hack" it with the .culture files.

Closes #2